### PR TITLE
Remove song as user - backend changes

### DIFF
--- a/karaoke-server/Cargo.toml
+++ b/karaoke-server/Cargo.toml
@@ -37,3 +37,4 @@ csv = "1.3.0"
 log4rs = "1.2.0"
 serde_yaml = "0.9.30"
 zstd-sys = "=2.0.9" # workaround for https://github.com/gyscos/zstd-rs/issues/270
+sha256 = "1.5.0"

--- a/karaoke-server/src/websocket.rs
+++ b/karaoke-server/src/websocket.rs
@@ -19,7 +19,8 @@ use crate::AppState;
 #[serde(rename_all = "camelCase", tag = "cmd")]
 enum Command {
     Authenticate { password: String },
-    Add { song: i64, singer: String, password: String },
+    // If not password is set, tha song CAN NOT be deleted
+    Add { song: i64, singer: String, password: Option<String> },
     Play { id: Uuid },
     RemoveAsAdmin { id: Uuid },
     RemoveAsUser { id: Uuid, password: String },


### PR DESCRIPTION
This change are the backend changes to allow users to delete songs THEY added to the queue. This is done by extending the add function with a field called "password". This password will be hashed and the hash saved in the PlaylistEntry data. Further a new call has been added called DeleteAsUser. Tis requires the password as well. If the passwords match, a song can be deleted.

This commit also remames the previous "Remove" call to "RemoveAsAdmin" which works exactly the same way as it has allways done.

It adds a new field to the "Add" function called password.