### PR TITLE
Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM rust:slim-bookworm
+
+RUN apt-get update
+RUN apt-get install -y curl xz-utils chromium git pkg-config libavutil-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libswresample-dev libavdevice-dev clang libclang-dev llvm-dev
+
+RUN cargo install cargo-make
+
+# # download Flutter SDK
+RUN curl -L https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.22.3-stable.tar.xz | tar xJ 
+RUN mv flutter /usr/local/flutter
+
+RUN git config --global --add safe.directory /usr/local/flutter
+
+# # Set flutter environment path
+ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:${PATH}"
+ENV CHROME_EXECUTABLE="/usr/bin/chromium"
+
+
+# # Run flutter doctor
+RUN flutter doctor
+
+WORKDIR /usr/local/karaoke
+
+COPY importer importer
+COPY karaoke-server karaoke-server
+COPY karaokeparty karaokeparty
+COPY Cargo.toml .
+COPY Makefile.toml .
+
+
+RUN cargo make build-flutter
+RUN cargo make build-server
+
+
+COPY docker-run.sh .
+RUN chmod +x docker-run.sh
+
+COPY config.docker.yaml .
+ENTRYPOINT ["./docker-run.sh"]
+#ENTRYPOINT ["tail", "-f", "/dev/null"]
+
+

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ In these parties, people want to queue up for singing songs. They want to discov
 
 This implementation solves the problem by using technology.
 
-* The DJ has a computer at their station where they can host a central management server in the local WiFi, and they can see the list of upcoming songs.
-* The participants access the song database using their cellphone (or a shared station provided by the karaoke bar). They can search for songs, filter them, and then add  songs to the queue.
-* The DJ can also rearrange the song queue in case there's some special needs (like someone needing to sing right away because they're about to leave).
+- The DJ has a computer at their station where they can host a central management server in the local WiFi, and they can see the list of upcoming songs.
+- The participants access the song database using their cellphone (or a shared station provided by the karaoke bar). They can search for songs, filter them, and then add songs to the queue.
+- The DJ can also rearrange the song queue in case there's some special needs (like someone needing to sing right away because they're about to leave).
 
 The project consists of three programs:
 
-* The [importer](importer/), which scans the song library for metadata information and stores it in a sqlite database (for performance reasons).
-* The [karaoke-server](karaoke-server/), which has to run on the local network during the party.
-* The [karaokeparty](karaokeparty/) app, which is the (web) frontend people (participants and the DJ) are supposed to use during the party.
+- The [importer](importer/), which scans the song library for metadata information and stores it in a sqlite database (for performance reasons).
+- The [karaoke-server](karaoke-server/), which has to run on the local network during the party.
+- The [karaokeparty](karaokeparty/) app, which is the (web) frontend people (participants and the DJ) are supposed to use during the party.
 
 ## Dependencies
 
@@ -59,13 +59,19 @@ karaoke-server -c config.yaml
 
 The server can serve the frontend, the song database, and its own REST/WebSocket API at the same time. It's possible to have a reverse proxy in front of it, but it's not really necessary (unless TLS is desired).
 
-## Docker
+## Docker / Podman
+
+(Requires: `docker` + `docker-compose` or `podman` + `podman-compose`)
 
 Before running make sure to softlink the MasterCollection to `songs`. You can do this via: `ln -s /some/thing/MasterCollection songs`
+(Hint: If the `songs` folder already exist make sure to delete if first)
 
-You can run the docker container via `docker compose up`
+You can then run the docker container via `docker compose up` or `podman compose up`
 
-This build may take a long time (10min). If everything worked you should see the interface at 127.0.0.1:8080 and the covers should also load
+This build may take a long time (10min). If everything worked you should see the interface at `127.0.0.1:8080` and the covers should also load.
+If the covers don't load you may need to change the number for `-s` inside the `docker-run.sh` file and rebuild the container + delete the old `songs.db`.
+
+Info: If you want to recreate the songs database, then you should delete the file `songsdb/songs.db` and rerun the container.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ karaoke-server -c config.yaml
 
 The server can serve the frontend, the song database, and its own REST/WebSocket API at the same time. It's possible to have a reverse proxy in front of it, but it's not really necessary (unless TLS is desired).
 
+## Docker
+
+Before running make sure to softlink the MasterCollection to `songs`. You can do this via: `ln -s /some/thing/MasterCollection songs`
+
+You can run the docker container via `docker compose up`
+
+This build may take a long time (10min). If everything worked you should see the interface at 127.0.0.1:8080 and the covers should also load
+
 ## Contributions
 
 Contributions are welcome, please fork and open a pull request! You have to agree to use the same license as this project.

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -1,0 +1,41 @@
+paths:
+  database: ./songsdb/songs.db
+  media: songs
+  web_app: karaokeparty/build/web
+  playlist: playlist.json
+  song_log: song_log.csv
+  suggestion_log: suggestions.csv
+  bug_log: bugs.csv
+
+server:
+  listen: "0.0.0.0:8080"
+  password: abc
+
+logging:
+  appenders:
+    # An appender named "stdout" that writes to stdout
+    stdout:
+      kind: console
+    # An appender named "requests" that writes to a file with a custom pattern encoder
+    file:
+      kind: rolling_file
+      path: karaoke.log
+      policy:
+        kind: compound
+        trigger:
+          kind: size
+          limit: 10mb
+        roller:
+          kind: fixed_window
+          base: 1
+          count: 5
+          pattern: "karaoke.{}.log"
+      encoder:
+        pattern: "{d} [{f}:{L}] {l} - {h({m})}{n}"
+
+  # Set the default logging level to "warn" and attach the "stdout" appender to the root
+  root:
+    level: debug
+    appenders:
+      #      - file
+      - stdout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  karaoke:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./songsdb/:/usr/local/karaoke/songsdb/
+      - ./songs/:/usr/local/karaoke/songs/ 
+

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ ! -f ./songsdb/songs.db ]]; then
+  cargo run --bin importer -- --db ./songsdb/songs.db -s 5 ./songs/
+fi
+
+./target/release/karaoke-server -c config.docker.yaml

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ ! -f ./songsdb/songs.db ]]; then
-  cargo run --bin importer -- --db ./songsdb/songs.db -s 5 ./songs/
+  ./importer --db ./songsdb/songs.db -s 5 ./songs/
 fi
 
-./target/release/karaoke-server -c config.docker.yaml
+./karaoke-server -c config.docker.yaml


### PR DESCRIPTION
This pull-request adds a docker-compose script and a Dockerfile, that makes it easier to set up the KaraokeV2 service.

The scripts also work with podman.
A section in the `README.md` on how to use the docker scripts was also added.

I decided to not use `cargo-make`, because it extends the container build time significantly. I also tried using alpine images, but those did not contain some required files for building the flutter project.

When building the containers with podman I got the following container sizes:
* KaraokeV2: 1.57GB
* Builder: 6.41GB